### PR TITLE
Bugfix: ensure we reset the search path when the block raises an error.

### DIFF
--- a/lib/sequel/postgres/schemata.rb
+++ b/lib/sequel/postgres/schemata.rb
@@ -69,9 +69,13 @@ module Sequel
 
         def run_with_search_path path, &block
           old_path = search_path
-          self.search_path = path
-          yield
-          self.search_path = old_path
+
+          begin
+            self.search_path = path
+            yield
+          ensure
+            self.search_path = old_path
+          end
         end
 
         SHOW_SEARCH_PATH = "SHOW search_path".freeze

--- a/spec/schemata_spec.rb
+++ b/spec/schemata_spec.rb
@@ -30,6 +30,20 @@ describe Sequel::Postgres::Schemata do
         db.search_path.should == %i(foo public)
       end
 
+      it "resets the search path when the given block raises an error" do
+        class MyContrivedError < StandardError; end
+
+        begin
+          db.search_path :bar do
+            db.search_path.should == %i(bar)
+            raise MyContrivedError.new
+          end
+        rescue MyContrivedError
+          # Gobble.
+        end
+        db.search_path.should == %i(foo public)
+      end
+
       it "accepts symbols as arglist" do
         db.search_path :bar, :baz do
           db.search_path.should == %i(bar baz)


### PR DESCRIPTION
I came across this bug while using the schema search path block-style in tests -- a failing test I wrote caused all the subsequent tests to have the wrong schema search path that I meant to use temporarily.

Thanks for the library!
