### PR TITLE
Remove Sequel version number from gemspec

### DIFF
--- a/lib/sequel/postgres/schemata/version.rb
+++ b/lib/sequel/postgres/schemata/version.rb
@@ -1,7 +1,7 @@
 module Sequel
   module Postgres
     module Schemata
-      VERSION = "0.1.1"
+      VERSION = "0.1.2"
     end
   end
 end

--- a/sequel-postgres-schemata.gemspec
+++ b/sequel-postgres-schemata.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sequel", "~> 4.3"
-  
+  spec.add_runtime_dependency "sequel"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1"
   spec.add_development_dependency "rspec", "~> 2.14"


### PR DESCRIPTION
The code here does not appear specific to a Sequel version, so why lock it and prevent updates of Sequel to later versions.